### PR TITLE
Support for omitting prefix in `@Flatten`

### DIFF
--- a/core/src/main/scala/ste/selector.scala
+++ b/core/src/main/scala/ste/selector.scala
@@ -139,9 +139,9 @@ trait SelectorImplicits {
 
   private def getChildPrefixes(prefixes: List[Prefix], flatten: Option[Flatten]): List[Prefix] =
     flatten.map {
-      case Flatten(times, _) if times > 1 => (0 until times).flatMap(i => prefixes.map(_.addSuffix(i))).toList
-      case Flatten(_, keys) if keys.nonEmpty => keys.flatMap(k => prefixes.map(_.addSuffix(k))).toList
-      case Flatten(_, _) => prefixes
+      case Flatten(times, _, _) if times > 1 => (0 until times).flatMap(i => prefixes.map(_.addSuffix(i))).toList
+      case Flatten(_, keys,_ ) if keys.nonEmpty => keys.flatMap(k => prefixes.map(_.addSuffix(k))).toList
+      case Flatten(_, _,_ ) => prefixes
     }.getOrElse(prefixes)
 
   private def getNestedColumns(prefixes: List[Prefix], df: DataFrame, flatten: Flatten): Map[Prefix, Column] =
@@ -149,9 +149,9 @@ trait SelectorImplicits {
       val colName = prefix.toString
       val cols = groupedPrefixes.map(p => df(p.quotedString))
       flatten match {
-        case Flatten(times, _) if times > 1 => (prefix, array(cols :_*).as(colName))
-        case Flatten(_, keys) if keys.nonEmpty => (prefix, map(interleave(keys.map(lit), cols) :_*).as(colName))
-        case Flatten(_, _) => (groupedPrefixes.head, cols.head)
+        case Flatten(times, _, _) if times > 1 => (prefix, array(cols :_*).as(colName))
+        case Flatten(_, keys,_ ) if keys.nonEmpty => (prefix, map(interleave(keys.map(lit), cols) :_*).as(colName))
+        case Flatten(_, _,_ ) => (groupedPrefixes.head, cols.head)
       }
     }(breakOut)
 

--- a/core/src/test/scala/ste/StructTypeEncoderSpec.scala
+++ b/core/src/test/scala/ste/StructTypeEncoderSpec.scala
@@ -114,19 +114,26 @@ class StructTypeEncoderSpec extends FlatSpec with Matchers {
       .putString("bar", "baz")
       .build
 
-    case class Foo(a: String, @Meta(metadata) b: Int)
-    case class Bar(@Flatten(2) a: Seq[Foo], @Flatten(1, Seq("x", "y")) b: Map[String, Foo], @Flatten c: Foo)
+    case class Foo(fa: String, @Meta(metadata) fb: Int)
+    case class Bar(
+      @Flatten(2) a: Seq[Foo],
+      @Flatten(1, Seq("x", "y")) b: Map[String, Foo],
+      @Flatten c: Foo,
+      @Flatten(1, Seq(), omitPrefix = true) d: Foo
+    )
     StructTypeEncoder[Bar].encode shouldBe StructType(
-      StructField("a.0.a", StringType, false) ::
-      StructField("a.0.b", IntegerType, false, metadata) ::
-      StructField("a.1.a", StringType, false) ::
-      StructField("a.1.b", IntegerType, false, metadata) ::
-      StructField("b.x.a", StringType, false) ::
-      StructField("b.x.b", IntegerType, false, metadata) ::
-      StructField("b.y.a", StringType, false) ::
-      StructField("b.y.b", IntegerType, false, metadata) ::
-      StructField("c.a", StringType, false) ::
-      StructField("c.b", IntegerType, false, metadata) :: Nil
+      StructField("a.0.fa", StringType, false) ::
+      StructField("a.0.fb", IntegerType, false, metadata) ::
+      StructField("a.1.fa", StringType, false) ::
+      StructField("a.1.fb", IntegerType, false, metadata) ::
+      StructField("b.x.fa", StringType, false) ::
+      StructField("b.x.fb", IntegerType, false, metadata) ::
+      StructField("b.y.fa", StringType, false) ::
+      StructField("b.y.fb", IntegerType, false, metadata) ::
+      StructField("c.fa", StringType, false) ::
+      StructField("c.fb", IntegerType, false, metadata) ::
+      StructField("fa", StringType, false) ::
+      StructField("fb", IntegerType, false, metadata) :: Nil
     )
   }
 }


### PR DESCRIPTION
Sometimes it could be necessary to flatten a structure without prefixing the field names.