### PR TITLE
Support for omitting prefix in `@Flatten`

### DIFF
--- a/core/src/test/scala/ste/StructTypeEncoderSpec.scala
+++ b/core/src/test/scala/ste/StructTypeEncoderSpec.scala
@@ -114,19 +114,26 @@ class StructTypeEncoderSpec extends FlatSpec with Matchers {
       .putString("bar", "baz")
       .build
 
-    case class Foo(a: String, @Meta(metadata) b: Int)
-    case class Bar(@Flatten(2) a: Seq[Foo], @Flatten(1, Seq("x", "y")) b: Map[String, Foo], @Flatten c: Foo)
+    case class Foo(fa: String, @Meta(metadata) fb: Int)
+    case class Bar(
+      @Flatten(2) a: Seq[Foo],
+      @Flatten(1, Seq("x", "y")) b: Map[String, Foo],
+      @Flatten c: Foo,
+      @Flatten(1, Seq(), omitPrefix = true) d: Foo
+    )
     StructTypeEncoder[Bar].encode shouldBe StructType(
-      StructField("a.0.a", StringType, false) ::
-      StructField("a.0.b", IntegerType, false, metadata) ::
-      StructField("a.1.a", StringType, false) ::
-      StructField("a.1.b", IntegerType, false, metadata) ::
-      StructField("b.x.a", StringType, false) ::
-      StructField("b.x.b", IntegerType, false, metadata) ::
-      StructField("b.y.a", StringType, false) ::
-      StructField("b.y.b", IntegerType, false, metadata) ::
-      StructField("c.a", StringType, false) ::
-      StructField("c.b", IntegerType, false, metadata) :: Nil
+      StructField("a.0.fa", StringType, false) ::
+      StructField("a.0.fb", IntegerType, false, metadata) ::
+      StructField("a.1.fa", StringType, false) ::
+      StructField("a.1.fb", IntegerType, false, metadata) ::
+      StructField("b.x.fa", StringType, false) ::
+      StructField("b.x.fb", IntegerType, false, metadata) ::
+      StructField("b.y.fa", StringType, false) ::
+      StructField("b.y.fb", IntegerType, false, metadata) ::
+      StructField("c.fa", StringType, false) ::
+      StructField("c.fb", IntegerType, false, metadata) ::
+      StructField("fa", StringType, false) ::
+      StructField("fb", IntegerType, false, metadata) :: Nil
     )
   }
 }

--- a/core/src/test/scala/ste/StructTypeSelectorSpec.scala
+++ b/core/src/test/scala/ste/StructTypeSelectorSpec.scala
@@ -28,13 +28,15 @@ import StructTypeEncoder._
 import StructTypeSelector._
 
 object StructSelectorSpec {
-  case class Foo(a: Int, b: String)
-  case class Bar(@Flatten(1, Seq("asd", "qwe")) foo: Map[String, Foo], c: Int)
-  case class Baz(@Flatten(2) bar: Seq[Bar], e: Int)
-  case class Asd(@Flatten foo: Foo, x: Int)
-  case class Qwe(asd: Asd, y: Int)
-  case class Zxc(foo: Foo, x: Int)
-  case class Edx(@Flatten zxc: Zxc, y: Int)
+  case class A(x: Int, y: String)
+  case class B(@Flatten(1, Seq("asd", "qwe")) a: Map[String, A], z: Int)
+  case class C(@Flatten(2) b: Seq[B], w: Int)
+  case class D(@Flatten a: A, z: Int)
+  case class E(d: D, w: Int)
+  case class F(a: A, z: Int)
+  case class G(@Flatten f: F, w: Int)
+  case class H(@Flatten(1, Seq(), true) a: A, z: Int)
+  case class I(@Flatten h: H, w: Int)
 }
 
 class StructSelectorSpec extends FlatSpec with Matchers {
@@ -44,22 +46,22 @@ class StructSelectorSpec extends FlatSpec with Matchers {
   "selectNested" should "return the nested DataFrame" in {
     import spark.implicits._
     val values = List((1, "a", 2, "b", 3), (4, "c", 5, "d", 6))
-    val df = values.toDF(StructTypeEncoder[Bar].encode.fields.map(_.name) :_*)
-    val result = df.selectNested[Bar]
+    val df = values.toDF(StructTypeEncoder[B].encode.fields.map(_.name) :_*)
+    val result = df.selectNested[B]
     val expected = Array(
-      Bar(Map("asd" -> Foo(1, "a"), "qwe" -> Foo(2, "b")), 3),
-      Bar(Map("asd" -> Foo(4, "c"), "qwe" -> Foo(5, "d")), 6)
+      B(Map("asd" -> A(1, "a"), "qwe" -> A(2, "b")), 3),
+      B(Map("asd" -> A(4, "c"), "qwe" -> A(5, "d")), 6)
     )
-    result.as[Bar].collect shouldEqual expected
+    result.as[B].collect shouldEqual expected
   }
 
   it should "deal with flattened struct" in {
     import spark.implicits._
     val values = List((1, "a", 2), (3, "b", 4))
-    val df = values.toDF(StructTypeEncoder[Asd].encode.fields.map(_.name) :_*)
-    val result = df.asNested[Asd].collect
+    val df = values.toDF(StructTypeEncoder[D].encode.fields.map(_.name) :_*)
+    val result = df.asNested[D].collect
     val expected = Array(
-      Asd(Foo(1, "a"), 2), Asd(Foo(3, "b"), 4)
+      D(A(1, "a"), 2), D(A(3, "b"), 4)
     )
     result shouldEqual expected
   }
@@ -70,20 +72,20 @@ class StructSelectorSpec extends FlatSpec with Matchers {
       (1, "a", 2, "b", 3, 4, "c", 5, "d", 6, 7),
       (10, "aa", 20, "bb", 30, 40, "cc", 50, "dd", 60, 70)
     )
-    val df = values.toDF(StructTypeEncoder[Baz].encode.fields.map(_.name) :_*)
-    val result = df.asNested[Baz].collect
+    val df = values.toDF(StructTypeEncoder[C].encode.fields.map(_.name) :_*)
+    val result = df.asNested[C].collect
     val expected = Array(
-      Baz(
+      C(
         Seq(
-          Bar(Map("asd" -> Foo(1, "a"), "qwe" -> Foo(2, "b")), 3),
-          Bar(Map("asd" -> Foo(4, "c"), "qwe" -> Foo(5, "d")), 6)
+          B(Map("asd" -> A(1, "a"), "qwe" -> A(2, "b")), 3),
+          B(Map("asd" -> A(4, "c"), "qwe" -> A(5, "d")), 6)
         ),
         7
       ),
-      Baz(
+      C(
         Seq(
-          Bar(Map("asd" -> Foo(10, "aa"), "qwe" -> Foo(20, "bb")), 30),
-          Bar(Map("asd" -> Foo(40, "cc"), "qwe" -> Foo(50, "dd")), 60)
+          B(Map("asd" -> A(10, "aa"), "qwe" -> A(20, "bb")), 30),
+          B(Map("asd" -> A(40, "cc"), "qwe" -> A(50, "dd")), 60)
         ),
         70
       )
@@ -93,9 +95,9 @@ class StructSelectorSpec extends FlatSpec with Matchers {
 
   it should "deal with not flattened struct" in {
     import spark.implicits._
-    val df = spark.createDataset(List((Foo(1, "a"), 2), (Foo(3, "b"), 4))).toDF
-    val result = df.asNested[(Foo, Int)].collect
-    val expected = Array((Foo(1, "a"), 2), (Foo(3, "b"), 4))
+    val df = spark.createDataset(List((A(1, "a"), 2), (A(3, "b"), 4))).toDF
+    val result = df.asNested[(A, Int)].collect
+    val expected = Array((A(1, "a"), 2), (A(3, "b"), 4))
     result shouldEqual expected
   }
 
@@ -106,11 +108,11 @@ class StructSelectorSpec extends FlatSpec with Matchers {
       (4, "qwe", 5, 6)
     )
     val df = spark.createDataset(values).select(
-      struct($"_1".as("foo.a"), $"_2".as("foo.b"), $"_3".as("x")).as("asd"),
-      $"_4".as("y")
+      struct($"_1".as("a.x"), $"_2".as("a.y"), $"_3".as("z")).as("d"),
+      $"_4".as("w")
     )
-    val result = df.asNested[Qwe].collect
-    val expected = Array(Qwe(Asd(Foo(1, "asd"), 2), 3), Qwe(Asd(Foo(4, "qwe"), 5), 6))
+    val result = df.asNested[E].collect
+    val expected = Array(E(D(A(1, "asd"), 2), 3), E(D(A(4, "qwe"), 5), 6))
     result shouldEqual expected
   }
 
@@ -121,12 +123,12 @@ class StructSelectorSpec extends FlatSpec with Matchers {
       (4, "qwe", 5, 6)
     )
     val df = spark.createDataset(values).select(
-      struct($"_1".as("a"), $"_2".as("b")).as("zxc.foo"),
-      $"_3".as("zxc.x"),
-      $"_4".as("y")
+      struct($"_1".as("x"), $"_2".as("y")).as("f.a"),
+      $"_3".as("f.z"),
+      $"_4".as("w")
     )
-    val result = df.asNested[Edx].collect
-    val expected = Array(Edx(Zxc(Foo(1, "asd"), 2), 3), Edx(Zxc(Foo(4, "qwe"), 5), 6))
+    val result = df.asNested[G].collect
+    val expected = Array(G(F(A(1, "asd"), 2), 3), G(F(A(4, "qwe"), 5), 6))
     result shouldEqual expected
   }
 
@@ -135,6 +137,18 @@ class StructSelectorSpec extends FlatSpec with Matchers {
     val df = spark.createDataset(List((1 -> Seq(1, 2)), (3 -> Seq(4, 5)))).toDF
     val result = df.asNested[(Int, Seq[Int])].collect
     val expected = Array((1 -> Seq(1, 2)), (3 -> Seq(4, 5)))
+    result shouldEqual expected
+  }
+
+  it should "deal with omit prefix" in {
+    import spark.implicits._
+    val values = List(
+      (1, "asd", 2, 3),
+      (4, "qwe", 5, 6)
+    )
+    val df = values.toDF(StructTypeEncoder[I].encode.fields.map(_.name) :_*)
+    val result = df.asNested[I].collect
+    val expected = Array(I(H(A(1, "asd"), 2), 3), I(H(A(4, "qwe"), 5), 6))
     result shouldEqual expected
   }
 }


### PR DESCRIPTION
Sometimes it could be necessary to flatten a structure without prefixing the field names.